### PR TITLE
site title hiding issue fix.

### DIFF
--- a/style.css
+++ b/style.css
@@ -1487,7 +1487,7 @@ a:hover, a:active {
 	}
 }
 
-.site-header .site-branding .site-title {
+.site-title {
 	font-size: 40px;
 	line-height: 40px;
 	text-decoration: none;


### PR DESCRIPTION
When a user opts to hiding site-title, your `position:relative` overrides `position: absolute` making it still being visible, your selector is more **specific**. 